### PR TITLE
Add support for notification update on new articles

### DIFF
--- a/.envrctemplate
+++ b/.envrctemplate
@@ -1,20 +1,17 @@
 mkdir ./states
 
 # check if python version is set in current dir
-if [ -f ".python-version" ] ; then
-    if [ ! -d ".venv" ] ; then
-        echo "Installing virtualenv for $(python -V)"
-        python -m venv venv
-    fi
-    echo "Activating $(python -V) virtualenv"
-    source venv/bin/activate
-
-    # announce python version and show the path of the current python in ${PATH}
-    echo "Virtualenv has been activated for $(python -V)"
-    echo "Python is running from $(which python)"
-else
-    echo "Requested Python version not installed with pyenv"
+if [ ! -d ".venv" ] ; then
+    echo "Installing virtualenv for $(python3 -V)"
+    python3 -m venv .venv
 fi
+echo "Activating $(python3 -V) virtualenv"
+source .venv/bin/activate
 
-export MONGO_ADDRESS=[mongodb url]
+# announce python version and show the path of the current python in ${PATH}
+echo "Virtualenv has been activated for $(python -V)"
+echo "Python is running from $(which python)"
+
+export MONGO_ADDRESS=[address]
+export VOLUME_BACKEND_ENDPOINT=[endpoint]
 unset PS1

--- a/.envrctemplate
+++ b/.envrctemplate
@@ -1,4 +1,4 @@
-mkdir ./states
+mkdir ./.states
 
 # check if python version is set in current dir
 if [ ! -d ".venv" ] ; then
@@ -6,7 +6,7 @@ if [ ! -d ".venv" ] ; then
     python3 -m venv .venv
 fi
 echo "Activating $(python3 -V) virtualenv"
-source .venv/bin/activate
+layout python3
 
 # announce python version and show the path of the current python in ${PATH}
 echo "Virtualenv has been activated for $(python -V)"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ pip install -r requirements.txt
 ```
 
 ## Managing Environment
-We recommend using [pyenv](https://github.com/pyenv/pyenv) and [direnv](https://direnv.net/) for managing Python virtual environments.
+We recommend using [direnv](https://direnv.net/) and [venv](https://docs.python.org/3/tutorial/venv.html) for managing Python virtual environments.
 
 Set environment variables in the `.envrc` file outlined in the `.envrctemplate` file.
 

--- a/publications.json
+++ b/publications.json
@@ -1,199 +1,292 @@
 {
-    "publications": [
-        {
-            "bio": "The Advocate promotes the dissemination of literature that examines youth-related issues with the goal of encouraging youth advocacy in local and federal politics.",
-            "bioShort": "Encouraging political advocacy by examining issues relevant to college students",
-            "rssName": "The Advocate",
-            "rssURL": "http://theadvocatecornell.com/feed/",
-            "name": "The Advocate",
-            "slug": "advocate",
-            "socialURLs": [
-                {
-                    "social": "insta",
-                    "URL": "https://www.instagram.com/theadvocateatcornelluniversity"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/The-Advocate-at-Cornell-University-109632540936869"
-                }
-            ],
-            "websiteURL": "http://theadvocatecornell.com"
-        },
-        {
-            "bio": "Student-run entertainment and media organization dedicated exclusively to Cornell University Athletics.",
-            "bioShort": "Dedicated exclusively to Cornell Athletics",
-            "rssName": "Big Red Sports Network",
-            "rssURL": "https://www.bigredsportsnetwork.org/feed",
-            "name": "Big Red Sports Network",
-            "slug": "brsn",
-            "socialURLs": [
-                {
-                    "social": "insta",
-                    "URL": "https://www.instagram.com/cornellbrsn"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/CornellBRSN"
-                },
-                {
-                    "social": "youtube",
-                    "URL": "https://www.youtube.com/channel/UCXl9QF-FaKPR3ldQ9zkG0jg/videos"
-                },
-                {
-                    "social": "linkedin",
-                    "URL": "https://www.linkedin.com/company/bigredsportsnetwork"
-                },
-                {
-                    "social": "twitter",
-                    "URL": "https://twitter.com/CornellBRSN"
-                }
-            ],
-            "websiteURL": "https://www.bigredsportsnetwork.org"
-        },
-        {
-            "bio": "The Cornell Claritas is an ecumenical, interdenominational Christian publication that was founded on the hope of starting thoughtful Christian conversations within the academic community.",
-            "bioShort": "A journal of Christian thoughts",
-            "rssName": "Blog - CLARITAS",
-            "rssURL": "https://www.cornellclaritas.com/blog?format=rss",
-            "name": "Cornell Claritas",
-            "slug": "claritas",
-            "socialURLs": [
-                {
-                    "social": "insta",
-                    "URL": "https://www.instagram.com/cornellclaritas"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/CornellClaritas"
-                }
-            ],
-            "websiteURL": "https://www.cornellclaritas.com"
-        },
-        {
-            "bio": "We are a group of passionate food enthusiasts who come together to publish a diversity of recipes, articles and stories.",
-            "bioShort": "Recipes, stories, and articles from group of passionate food enthusiasts",
-            "rssName": "Blog - CRÈME de cornell",
-            "rssURL": "https://www.cremedecornell.net/blogposts?format=rss",
-            "name": "Crème de Cornell",
-            "slug": "creme",
-            "socialURLs": [
-                {
-                    "social": "insta",
-                    "URL": "https://www.instagram.com/cremedecornell/?hl=en"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/CremedeCornell"
-                }
-            ],
-            "websiteURL": "https://www.cremedecornell.net"
-        },
-        {
-            "bio": "Guac is an award-winning travel publication run by an interdisciplinary group of students at Cornell University.",
-            "bioShort": "Celebrating cultural diversity and view the world with an open mind",
-            "rssName": "Guac Magazine - Medium",
-            "rssURL": "https://medium.com/feed/guac-magazine",
-            "name": "Guac Magazine",
-            "slug": "guac",
-            "socialURLs": [
-                {
-                    "social": "insta",
-                    "URL": "https://www.instagram.com/guacmag/?hl=en"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/guacmag"
-                },
-                {
-                    "social": "linkedin",
-                    "URL": "https://www.linkedin.com/company/guac-magazine/about"
-                }
-            ],
-            "websiteURL": "https://medium.com/guac-magazine"
-        },
-        {
-            "bio": "Takes fresh from the sticky part of our rejected article pile.",
-            "bioShort": "News published with the utmost regard for veracity and originality",
-            "rssName": "CU Nooz",
-            "rssURL": "http://cunooz.com/feed/",
-            "name": "CU Nooz",
-            "slug": "nooz",
-            "socialURLs": [
-                {
-                    "social": "twitter",
-                    "URL": "https://twitter.com/cunooz?lang=en"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/cunoozzz"
-                }
-            ],
-            "websiteURL": "http://cunooz.com"
-        },
-        {
-            "bio": "The Cornell Review is an independent newspaper published by students of Cornell University in Ithaca, New York.",
-            "bioShort": "One of the leading college conservative publications in the United States",
-            "rssName": "The Cornell Review",
-            "rssURL": "https://www.thecornellreview.org/feed",
-            "name": "The Cornell Review",
-            "slug": "review",
-            "socialURLs": [
-                {
-                    "social": "twitter",
-                    "URL": "https://twitter.com/cornellreview?lang=en"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/thecornellreview"
-                }
-            ],
-            "websiteURL": "https://www.thecornellreview.org"
-        },
-        {
-            "bio": "As Cornell’s multimedia powerhouse, Slope Media Group is a leader in Cornell-related media and entertainment, delivering a creative, student perspective on everything that matters to the Big Red community.",
-            "bioShort": "Your daily fix of Cornell buzz",
-            "rssName": "All - Slope Media",
-            "rssURL": "https://www.slopemedia.org/all?format=rss",
-            "name": "Slope Media",
-            "slug": "slope",
-            "socialURLs": [
-                {
-                    "social": "insta",
-                    "URL": "https://www.instagram.com/slopemedia"
-                },
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/slopemedia"
-                },
-                {
-                    "social": "youtube",
-                    "URL": "https://www.youtube.com/user/SlopeMediaTV"
-                },
-                {
-                    "social": "spotify",
-                    "URL": "https://open.spotify.com/user/slopemedia?si=2_IbqlxtTP6O0fFkVp2GWA&nd=1"
-                }
-            ],
-            "websiteURL": "https://www.slopemedia.org"
-        },
-        {
-            "bio": "We created the review to provide a forum for the exchange of these ideas.",
-            "bioShort": "An open platform for scholarly writing, critical thinking, and reasoned debate",
-            "rssName": "The Undergraduate Law & Society Review at Cornell",
-            "rssURL": "https://www.culsr.org/?format=rss",
-            "name": "The Undergraduate Law and Society Review at Cornell",
-            "slug": "ulsr",
-            "socialURLs": [
-                {
-                    "social": "facebook",
-                    "URL": "https://www.facebook.com/CULSReview"
-                },
-                {
-                    "social": "linkedin",
-                    "URL": "https://www.linkedin.com/company/cornellundergraduatelawandsocietyreview/"
-                }
-            ],
-            "websiteURL": "https://www.culsr.org/"
-        }
+    "publications":[
+       {
+          "bio":"The Advocate promotes the dissemination of literature that examines youth-related issues with the goal of encouraging youth advocacy in local and federal politics.",
+          "bioShort":"Encouraging political advocacy by examining issues relevant to college students",
+          "rssName":"The Advocate",
+          "rssURL":"http://theadvocatecornell.com/feed/",
+          "name":"The Advocate",
+          "slug":"advocate",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/theadvocateatcornelluniversity"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/The-Advocate-at-Cornell-University-109632540936869"
+             }
+          ],
+          "websiteURL":"http://theadvocatecornell.com"
+       },
+       {
+          "bio":"Student-run entertainment and media organization dedicated exclusively to Cornell University Athletics.",
+          "bioShort":"Dedicated exclusively to Cornell Athletics",
+          "rssName":"Big Red Sports Network",
+          "rssURL":"https://www.bigredsportsnetwork.org/feed",
+          "name":"Big Red Sports Network",
+          "slug":"brsn",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/cornellbrsn"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/CornellBRSN"
+             },
+             {
+                "social":"youtube",
+                "URL":"https://www.youtube.com/channel/UCXl9QF-FaKPR3ldQ9zkG0jg/videos"
+             },
+             {
+                "social":"linkedin",
+                "URL":"https://www.linkedin.com/company/bigredsportsnetwork"
+             },
+             {
+                "social":"twitter",
+                "URL":"https://twitter.com/CornellBRSN"
+             }
+          ],
+          "websiteURL":"https://www.bigredsportsnetwork.org"
+       },
+       {
+          "bio":"The Cornell Claritas is an ecumenical, interdenominational Christian publication that was founded on the hope of starting thoughtful Christian conversations within the academic community.",
+          "bioShort":"A journal of Christian thoughts",
+          "rssName":"Blog - CLARITAS",
+          "rssURL":"https://www.cornellclaritas.com/blog?format=rss",
+          "name":"Cornell Claritas",
+          "slug":"claritas",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/cornellclaritas"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/CornellClaritas"
+             }
+          ],
+          "websiteURL":"https://www.cornellclaritas.com"
+       },
+       {
+          "bio":"We are a group of passionate food enthusiasts who come together to publish a diversity of recipes, articles and stories.",
+          "bioShort":"Recipes, stories, and articles from group of passionate food enthusiasts",
+          "rssName":"Blog - CRÈME de cornell",
+          "rssURL":"https://www.cremedecornell.net/blogposts?format=rss",
+          "name":"Crème de Cornell",
+          "slug":"creme",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/cremedecornell/?hl=en"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/CremedeCornell"
+             }
+          ],
+          "websiteURL":"https://www.cremedecornell.net"
+       },
+       {
+          "bio":"Guac is an award-winning travel publication run by an interdisciplinary group of students at Cornell University.",
+          "bioShort":"Celebrating cultural diversity and view the world with an open mind",
+          "rssName":"Guac Magazine - Medium",
+          "rssURL":"https://medium.com/feed/guac-magazine",
+          "name":"Guac Magazine",
+          "slug":"guac",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/guacmag/?hl=en"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/guacmag"
+             },
+             {
+                "social":"linkedin",
+                "URL":"https://www.linkedin.com/company/guac-magazine/about"
+             }
+          ],
+          "websiteURL":"https://medium.com/guac-magazine"
+       },
+       {
+          "bio":"Takes fresh from the sticky part of our rejected article pile.",
+          "bioShort":"News published with the utmost regard for veracity and originality",
+          "rssName":"CU Nooz",
+          "rssURL":"http://cunooz.com/feed/",
+          "name":"CU Nooz",
+          "slug":"nooz",
+          "socialURLs":[
+             {
+                "social":"twitter",
+                "URL":"https://twitter.com/cunooz?lang=en"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/cunoozzz"
+             }
+          ],
+          "websiteURL":"http://cunooz.com"
+       },
+       {
+          "bio":"The Cornell Review is an independent newspaper published by students of Cornell University in Ithaca, New York.",
+          "bioShort":"One of the leading college conservative publications in the United States",
+          "rssName":"The Cornell Review",
+          "rssURL":"https://www.thecornellreview.org/feed",
+          "name":"The Cornell Review",
+          "slug":"review",
+          "socialURLs":[
+             {
+                "social":"twitter",
+                "URL":"https://twitter.com/cornellreview?lang=en"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/thecornellreview"
+             }
+          ],
+          "websiteURL":"https://www.thecornellreview.org"
+       },
+       {
+          "bio":"As Cornell’s multimedia powerhouse, Slope Media Group is a leader in Cornell-related media and entertainment, delivering a creative, student perspective on everything that matters to the Big Red community.",
+          "bioShort":"Your daily fix of Cornell buzz",
+          "rssName":"All - Slope Media",
+          "rssURL":"https://www.slopemedia.org/all?format=rss",
+          "name":"Slope Media",
+          "slug":"slope",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/slopemedia"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/slopemedia"
+             },
+             {
+                "social":"youtube",
+                "URL":"https://www.youtube.com/user/SlopeMediaTV"
+             },
+             {
+                "social":"spotify",
+                "URL":"https://open.spotify.com/user/slopemedia?si=2_IbqlxtTP6O0fFkVp2GWA&nd=1"
+             }
+          ],
+          "websiteURL":"https://www.slopemedia.org"
+       },
+       {
+          "bio":"We created the review to provide a forum for the exchange of these ideas.",
+          "bioShort":"An open platform for scholarly writing, critical thinking, and reasoned debate",
+          "rssName":"The Undergraduate Law & Society Review at Cornell",
+          "rssURL":"https://www.culsr.org/?format=rss",
+          "name":"The Undergraduate Law and Society Review at Cornell",
+          "slug":"ulsr",
+          "socialURLs":[
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/CULSReview"
+             },
+             {
+                "social":"linkedin",
+                "URL":"https://www.linkedin.com/company/cornellundergraduatelawandsocietyreview/"
+             }
+          ],
+          "websiteURL":"https://www.culsr.org/"
+       },
+       {
+          "bio":"Cornell Data Journal is an online investigative journalism publication featuring data visualization, data communication, and interdisciplinary research pieces.",
+          "bioShort":"Offering data-driven perspectives on current events, academics, politics, and beyond.",
+          "rssName":"Cornell Data Journal",
+          "rssURL":"https://cdj-git-add-rss-ashpil.vercel.app/rss.xml",
+          "name":"Cornell Data Journal",
+          "slug":"cdj",
+          "socialURLs":[
+             {
+                "social":"twitter",
+                "URL":"https://cornelldatajourn.al/socials/twitter.svg"
+             },
+             {
+                "social":"linkedin",
+                "URL":"https://www.linkedin.com/company/cornell-data-journal/"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/cornelldatajournal/"
+             },
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/cornelldatajournal/"
+             }
+          ],
+          "websiteURL":"https://cornelldatajourn.al/"
+       },
+       {
+          "bio":"We are a community of Cornell students who love creating.",
+          "bioShort":"We are a community of Cornell students who love creating.",
+          "rssName":"Cornell Creatives Newsletter",
+          "rssURL":"https://cornell.substack.com/feed",
+          "name":"Cornell Creatives Blog",
+          "slug":"creatives",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/cornellcreatives/"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/cornellcreatives/"
+             },
+             {
+                "social":"linkedin",
+                "URL":"https://www.linkedin.com/company/30581251/"
+             }
+          ],
+          "websiteURL":"https://cornellcreatives.com/"
+       },
+       {
+          "bio":"The 180 is a publication by Hotelies for Hotelies. We aim to not only highlight the culture of Cornell University’s Hotel School through a 180 degree perspective, but to also capsule the community’s memories physically through an annual print.",
+          "bioShort":"The 180 is a publication by Hotelies for Hotelies.",
+          "rssName":"The 180 Blog - The 180",
+          "rssURL":"https://www.the180print.org/the-180-blog?format=rss",
+          "name":"The 180 at Cornell",
+          "slug":"180",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/the_180_cornell/?hl=en"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/Cornell.the180/"
+             },
+             {
+                "social":"linkedin",
+                "URL":"https://www.linkedin.com/company/cornell-the180/"
+             }
+          ],
+          "websiteURL":"https://www.the180print.org/"
+       },
+       {
+          "bio":"We are a student-run international affairs magazine that brings together writers, editors and artists to tackle global problems from a variety of perspectives.",
+          "bioShort":" Global Issues. Complex Challenges. Student Perspectives.",
+          "rssName":"Borders - The Cornell Diplomat",
+          "rssURL":"https://www.thecornelldiplomat.com/issue4?format=rss",
+          "name":"The Cornell Diplomat",
+          "slug":"diplo",
+          "socialURLs":[
+             {
+                "social":"insta",
+                "URL":"https://www.instagram.com/thecornelldiplomat/"
+             },
+             {
+                "social":"facebook",
+                "URL":"https://www.facebook.com/TheCornellDiplomat/"
+             }
+          ],
+          "websiteURL":"https://www.thecornelldiplomat.com/"
+       }
+ 
     ]
-}
+ }

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,10 @@ nodeenv==1.6.0
 pathspec==0.8.1
 pre-commit==2.12.1
 pymongo==3.11.3
+python-dateutil==2.8.2 
 PyYAML==5.4.1
 regex==2021.4.4
+requests==2.26.0
 schedule==1.1.0
 sgmllib3k==1.0.0
 six==1.15.0

--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,7 @@ import requests
 import schedule
 import time
 from article import Article
+from constants import STATES_LOCATION
 from publication import Publication
 from pymongo import MongoClient, UpdateOne
 
@@ -40,12 +41,13 @@ def gather_articles():
     with MongoClient(MONGO_ADDRESS) as client:
         db = client.volume
         result = db.articles.bulk_write(article_upserts).upserted_ids
+        # Need to unwrap ObjectID objects from MongoDB into str ids
         article_ids = map(str, list(result.values()))
         response = requests.post(VOLUME_BACKEND_ADDRESS, data={'articleIDs': article_ids})
 
 # Before first run, clear states
-for f in os.listdir('./states/'):
-    os.remove(os.path.join('./states/', f))
+for f in os.listdir(STATES_LOCATION):
+    os.remove(os.path.join(STATES_LOCATION, f))
 
 # Get initial refresh
 gather_articles()

--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import requests
 import schedule
 import time
 from article import Article
@@ -11,6 +12,7 @@ with open("publications.json") as f:
     publications_json = json.load(f)["publications"]
 
 MONGO_ADDRESS = os.getenv("MONGO_ADDRESS")
+VOLUME_BACKEND_ADDRESS = os.getenv("VOLUME_BACKEND_ADDRESS")
 
 # Get serialized publications
 publications = [Publication(p).serialize() for p in publications_json]
@@ -19,7 +21,7 @@ publication_upserts = [
 ]
 # Add publications to db
 with MongoClient(MONGO_ADDRESS) as client:
-    db = client.microphone
+    db = client.volume
     result = db.publications.bulk_write(publication_upserts)
 
 # Function for gathering articles for running with scheduler
@@ -31,14 +33,19 @@ def gather_articles():
             articles.append(Article(entry, publication["slug"]).serialize())
 
     article_upserts = [
-        UpdateOne({"articleUrl": a["articleUrl"]}, {"$setOnInsert": a}, upsert=True)
+        UpdateOne({"articleURL": a["articleURL"]}, {"$setOnInsert": a}, upsert=True)
         for a in articles
     ]
     # Add articles to db
     with MongoClient(MONGO_ADDRESS) as client:
-        db = client.microphone
-        result = db.articles.bulk_write(article_upserts)
+        db = client.volume
+        result = db.articles.bulk_write(article_upserts).upserted_ids
+        article_ids = map(str, list(result.values()))
+        response = requests.post(VOLUME_BACKEND_ADDRESS, data={'articleIDs': article_ids})
 
+# Before first run, clear states
+for f in os.listdir('./states/'):
+    os.remove(os.path.join('./states/', f))
 
 # Get initial refresh
 gather_articles()

--- a/src/article.py
+++ b/src/article.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 from datetime import datetime
-from time import mktime
+from dateutil import parser as date_parser
 
 
 class Article:
@@ -16,14 +16,13 @@ class Article:
         return ""
 
     def get_date(self):
-        time_tuple = self.entry.published_parsed
-        return datetime.fromtimestamp(mktime(time_tuple))
+        return date_parser.parse(self.entry.published)
 
     def serialize(self):
         return {
-            "articleUrl": self.entry.link,
+            "articleURL": self.entry.link,
             "date": self.get_date(),
-            "imageUrl": self.get_img(),
+            "imageURL": self.get_img(),
             "publicationSlug": self.slug,
             "title": self.entry.title,
         }

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,1 +1,2 @@
 IMAGE_ADDRESS = "https://raw.githubusercontent.com/cuappdev/assets/master/volume/"
+STATES_LOCATION = "./.states/"

--- a/src/publication.py
+++ b/src/publication.py
@@ -42,5 +42,6 @@ class Publication:
             "profileImageUrl": pub_img("profile"),
             "rssName": self.publication["rssName"],
             "rssUrl": self.publication["rssURL"],
+            "slug":  self.publication["slug"],
             "websiteUrl": self.publication["websiteURL"],
         }

--- a/src/publication.py
+++ b/src/publication.py
@@ -1,7 +1,7 @@
 import feedparser
 import json
 import os
-from constants import IMAGE_ADDRESS
+from constants import IMAGE_ADDRESS, STATES_LOCATION
 
 
 class Publication:
@@ -9,7 +9,7 @@ class Publication:
         self.publication = publication
 
     def get_feed(self):
-        state_file = f"states/.state_{self.publication['slug']}.json"
+        state_file = f"{STATES_LOCATION}/.state_{self.publication['slug']}.json"
         # Get state files, if none exist initialize to empty
         try:
             with open(state_file, "r") as f:


### PR DESCRIPTION
Add request to `volume-backend` which sends a request with newly added article ids.

Also updates the following:
* date parsing with `python-dateutil` providing more resilient parsing
* deleting state files on initial startup
* match schema to `volume-backend`