### PR TITLE
Implement placeholder images

### DIFF
--- a/src/article.py
+++ b/src/article.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from constants import PLACEHOLDER_IMAGE_ADDRESS
 from datetime import datetime
 from dateutil import parser as date_parser
 
@@ -9,11 +10,12 @@ class Article:
         self.publication = publication.serialize()
 
     def get_img(self):
+        default_image_url = PLACEHOLDER_IMAGE_ADDRESS + "/" + self.publication["slug"] + ".png"
         if "content" in self.entry:
             soup = BeautifulSoup(self.entry.content[0].value, features="html.parser")
             img = soup.find("img")
-            return img["src"] if img else ""
-        return ""
+            return img["src"] if img else default_image_url
+        return default_image_url
 
     def get_date(self):
         return date_parser.parse(self.entry.published)

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,3 +1,3 @@
 IMAGE_ADDRESS = "https://raw.githubusercontent.com/cuappdev/assets/master/volume"
-STATES_LOCATION = "../.states/"
+STATES_LOCATION = "./.states/"
 PLACEHOLDER_IMAGE_ADDRESS = "https://raw.githubusercontent.com/cuappdev/assets/master/volume/placeholders/"

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,2 +1,3 @@
 IMAGE_ADDRESS = "https://raw.githubusercontent.com/cuappdev/assets/master/volume"
-STATES_LOCATION = "./.states/"
+STATES_LOCATION = "../.states/"
+PLACEHOLDER_IMAGE_ADDRESS = "https://raw.githubusercontent.com/cuappdev/assets/master/volume/placeholders/"


### PR DESCRIPTION
This PR makes it so that if an empty `imageURL` is detected on an article, the imageURL will default to placeholders imageURL. 

This PR should be paired with a migration script on volume-backend that updates all current articles

## Overview

This PR makes it so that if an empty  imageURL is detected when creating a new article, the imageURL will default to a placeholder image  in our assets repo.

## Test Coverage
Tested on local articles database when inserting new articles.

## Next Steps
- Create a migration script on volume-backend that updates all existing articles with empty imageURLs to use placeholder images.

