### PR TITLE
Add filtering capabilities to microservice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ sgmllib3k==1.0.0
 six==1.15.0
 soupsieve==2.2.1
 toml==0.10.2
+better-profanity==0.7.0

--- a/src/article.py
+++ b/src/article.py
@@ -33,15 +33,13 @@ class Article:
             "publicationSlug": self.publication["slug"],
             "publication": self.publication,
             "title": self.entry.title,
-            "isFiltered": self.isProfane(),
+            "isFiltered": self.is_profane(),
         }
 
-    def isProfane(self):
+    def is_profane(self):
         content = ""
-        check_content = False
-        try:  # Sometimes the entry doesn't have a content field
+        is_content_profane = False
+        if "content" in self.entry:
             content = self.entry.content[0]["value"]
-            check_content = pf.contains_profanity(content)
-        except:
-            pass
-        return pf.contains_profanity(self.entry.title) or check_content
+            is_content_profane = pf.contains_profanity(content)
+        return pf.contains_profanity(self.entry.title) or is_content_profane

--- a/src/article.py
+++ b/src/article.py
@@ -33,7 +33,7 @@ class Article:
             "publicationSlug": self.publication["slug"],
             "publication": self.publication,
             "title": self.entry.title,
-            "filtered": self.isProfane(),
+            "isFiltered": self.isProfane(),
         }
 
     def isProfane(self):

--- a/src/article.py
+++ b/src/article.py
@@ -1,12 +1,14 @@
 from bs4 import BeautifulSoup
-from constants import PLACEHOLDER_IMAGE_ADDRESS
+from constants import PLACEHOLDER_IMAGE_ADDRESS, FILTERED_WORDS
 from datetime import datetime
 from dateutil import parser as date_parser
 from constants import IMAGE_ADDRESS
+from better_profanity import profanity as pf
 
 
 class Article:
     def __init__(self, entry, publication):
+        pf.load_censor_words(FILTERED_WORDS)
         self.entry = entry
         self.publication = publication.serialize()
 
@@ -31,4 +33,15 @@ class Article:
             "publicationSlug": self.publication["slug"],
             "publication": self.publication,
             "title": self.entry.title,
+            "filtered": self.isProfane(),
         }
+
+    def isProfane(self):
+        content = ""
+        check_content = False
+        try:  # Sometimes the entry doesn't have a content field
+            content = self.entry.content[0]["value"]
+            check_content = pf.contains_profanity(content)
+        except:
+            pass
+        return pf.contains_profanity(self.entry.title) or check_content

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,3 +1,6 @@
 IMAGE_ADDRESS = "https://raw.githubusercontent.com/cuappdev/assets/master/volume"
 STATES_LOCATION = "./.states/"
-PLACEHOLDER_IMAGE_ADDRESS = "https://raw.githubusercontent.com/cuappdev/assets/master/volume/placeholders/"
+PLACEHOLDER_IMAGE_ADDRESS = (
+    "https://raw.githubusercontent.com/cuappdev/assets/master/volume/placeholders/"
+)
+FILTERED_WORDS = ["covid-19", "coronavirus"]


### PR DESCRIPTION
Set up filtering by keywords that checks article titles and bodies. Sets the `filtered` field to `true` if there is a match. 

Tested by running through all articles pulled and inspecting what words were filtered. 
One concern for the future is that the filtering library automatically replaces letters such as "u" with "v" and "l" with "i" to get around hiding profane words. For example, filtering articles containing "covid" would also filter articles containing "could". There isn't a way to disable this, so we might have to fork the library in the future and change the behavior if adding new keywords.