### PR TITLE
Add cover image png to serialization of magazine.

### DIFF
--- a/publications.json
+++ b/publications.json
@@ -397,7 +397,7 @@
       "bioShort": "Independent since 1880.",
       "contentTypes": ["articles"],
       "rssName": "The Cornell Daily Sun",
-      "rssURL": null,
+      "rssURL": "https://cornellsun.com/feed/",
       "name": "The Cornell Daily Sun",
       "slug": "sun",
       "socialURLs": [

--- a/publications.json
+++ b/publications.json
@@ -313,30 +313,6 @@
       "websiteURL": "https://cornellcreatives.com/"
     },
     {
-      "bio": "The 180 is a publication by Hotelies for Hotelies. We aim to not only highlight the culture of Cornell University’s Hotel School through a 180 degree perspective, but to also capsule the community’s memories physically through an annual print.",
-      "bioShort": "The 180 is a publication by Hotelies for Hotelies.",
-      "contentTypes": ["articles"],
-      "rssName": "The 180 Blog - The 180",
-      "rssURL": "https://www.the180print.org/the-180-blog?format=rss",
-      "name": "The 180 at Cornell",
-      "slug": "180",
-      "socialURLs": [
-        {
-          "social": "insta",
-          "URL": "https://www.instagram.com/the_180_cornell/?hl=en"
-        },
-        {
-          "social": "facebook",
-          "URL": "https://www.facebook.com/Cornell.the180/"
-        },
-        {
-          "social": "linkedin",
-          "URL": "https://www.linkedin.com/company/cornell-the180/"
-        }
-      ],
-      "websiteURL": "https://www.the180print.org/"
-    },
-    {
       "bio": "We are a student-run international affairs magazine that brings together writers, editors and artists to tackle global problems from a variety of perspectives.",
       "bioShort": " Global Issues. Complex Challenges. Student Perspectives.",
       "contentTypes": ["articles"],
@@ -405,7 +381,7 @@
       "bioShort": "Everything about science, health, and medicine.",
       "contentTypes": ["articles"],
       "rssName": "The Cornell Healthcare Review",
-      "rssURL": "https://www.cornellhealthcarereview.org/blogs-feed.xml",
+      "rssURL": "https://www.cornellhealthcarereview.org/blog-feed.xml",
       "name": "The Cornell Healthcare Review",
       "slug": "healthcare",
       "socialURLs": [
@@ -421,7 +397,7 @@
       "bioShort": "Independent since 1880.",
       "contentTypes": ["articles"],
       "rssName": "The Cornell Daily Sun",
-      "rssURL": "https://cornellsun.com/feed/",
+      "rssURL": null,
       "name": "The Cornell Daily Sun",
       "slug": "sun",
       "socialURLs": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ gdown==4.4.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
+Pillow==9.5.0
+pypdfium2==4.4.0

--- a/src/magazine.py
+++ b/src/magazine.py
@@ -11,6 +11,7 @@ import io
 import json
 import os
 import requests
+import pypdfium2 as pdfium
 
 
 class Magazine:
@@ -26,9 +27,15 @@ class Magazine:
         self.publication = publication
 
     def download_magazine(self, id):
+        """
+        pdf response and first image response from appdev upload service
+        
+        returns response tuple (<pdf_response>, <first_page_response>):
+        ({"success": <bool>, "data": "<pdf url?>"}, {"success": <bool>, "data": "<first page png url?>"})
+        """
         creds = service_account.Credentials.from_service_account_file(
-            os.getenv("GOOGLE_SERVICE_ACCOUNT_PATH")
-        )
+            os.getenv("GOOGLE_SERVICE_ACCOUNT_PATH"))
+        
         try:
             # create drive api client
             service = build("drive", "v3", credentials=creds)
@@ -40,31 +47,52 @@ class Magazine:
             done = False
             while done is False:
                 status, done = downloader.next_chunk()
-
+                
         except HttpError as error:
             print(f"An error occurred: {error}")
             file = None
+            
         if file is not None:
-            payload = json.dumps(
-                {
-                    "bucket": UPLOAD_BUCKET,
-                    "image": "data:application/pdf;base64,"
-                    + base64.b64encode(file.getvalue()).decode("utf-8"),
-                }
-            )
-            return requests.post(
-                "https://upload.cornellappdev.com/upload/",
-                payload,
-            ).text
+            pdf = pdfium.PdfDocument(file)
+            first_page = pdf[0]
+            pil_image = first_page.render().to_pil().resize((150,220))
+
+            imageBytes = io.BytesIO() #create bytes stream to hold image
+            pil_image.save(imageBytes, format='png')
+            
+            image_payload = json.dumps(
+            {
+            "bucket": "volume",
+            "image": "data:image/png;base64,"
+            + base64.b64encode(imageBytes.getvalue()).decode("utf-8")})
+            
+            image_response = requests.post("https://upload.cornellappdev.com/upload/",image_payload).text
+
+            pdf_payload = json.dumps(
+                {"bucket": UPLOAD_BUCKET,
+                "image": "data:application/pdf;base64,"
+                + base64.b64encode(file.getvalue()).decode("utf-8")})
+            
+            pdf_response  = requests.post("https://upload.cornellappdev.com/upload/",pdf_payload).text
+            
+            return (pdf_response, image_response)
         return None
 
     def get_date(self, date):
         return date_parser.parse(date)
 
     def serialize(self):
-        response = self.download_magazine(id)
-        response = json.loads(response)
-        if response["success"]:
+        pdf_response = self.download_magazine(id)[0]
+        image_response = self.download_magazine(id)[1]
+        
+        image_response_obj = json.loads(image_response)
+        if image_response_obj["success"]:
+            image_url = image_response_obj["data"]
+        else:
+            raise Exception
+        pdf_response_obj = json.loads(pdf_response)
+        if pdf_response_obj["success"]:
+            pdf_url = pdf_response_obj["data"]
             return {
                 "date": self.get_date(self.timestamp),
                 "published": self.date_pub,
@@ -72,7 +100,8 @@ class Magazine:
                 "title": self.title,
                 "publicationSlug": self.slug,
                 "publication": self.publication,
-                "pdfURL": response["data"],
+                "pdfURL": pdf_url,
+                "imageURL": image_url,
                 "isFiltered": self.is_profane(),
             }
         else:

--- a/src/magazine.py
+++ b/src/magazine.py
@@ -34,7 +34,8 @@ class Magazine:
         ({"success": <bool>, "data": "<pdf url?>"}, {"success": <bool>, "data": "<first page png url?>"})
         """
         creds = service_account.Credentials.from_service_account_file(
-            os.getenv("GOOGLE_SERVICE_ACCOUNT_PATH"))
+            os.getenv("GOOGLE_SERVICE_ACCOUNT_PATH")
+        )
         
         try:
             # create drive api client
@@ -60,20 +61,21 @@ class Magazine:
             imageBytes = io.BytesIO() #create bytes stream to hold image
             pil_image.save(imageBytes, format='png')
             
-            image_payload = json.dumps(
-            {
-            "bucket": "volume",
-            "image": "data:image/png;base64,"
-            + base64.b64encode(imageBytes.getvalue()).decode("utf-8")})
+            image_payload = json.dumps({
+                "bucket": "volume",
+                "image": "data:image/png;base64,"
+                + base64.b64encode(imageBytes.getvalue()).decode("utf-8")
+            })
             
             image_response = requests.post("https://upload.cornellappdev.com/upload/",image_payload).text
 
-            pdf_payload = json.dumps(
-                {"bucket": UPLOAD_BUCKET,
+            pdf_payload = json.dumps({
+                "bucket": UPLOAD_BUCKET,
                 "image": "data:application/pdf;base64,"
-                + base64.b64encode(file.getvalue()).decode("utf-8")})
+                + base64.b64encode(file.getvalue()).decode("utf-8")
+            })
             
-            pdf_response  = requests.post("https://upload.cornellappdev.com/upload/",pdf_payload).text
+            pdf_response = requests.post("https://upload.cornellappdev.com/upload/",pdf_payload).text
             
             return (pdf_response, image_response)
         return None

--- a/src/magazine.py
+++ b/src/magazine.py
@@ -1,18 +1,10 @@
 from __future__ import print_function
-import base64
 from better_profanity import profanity as pf
-from constants import FILTERED_WORDS, UPLOAD_BUCKET
+from constants import FILTERED_WORDS
 from dateutil import parser as date_parser
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
-from googleapiclient.http import MediaIoBaseDownload
-from google.oauth2 import service_account
-import io
-import json
-import os
-import requests
-import pypdfium2 as pdfium
 
+import json
+import utils
 
 class Magazine:
     def __init__(self, sheet_row, publication):
@@ -26,84 +18,23 @@ class Magazine:
         self.semester = sheet_row[6].lower()
         self.publication = publication
 
-    def download_magazine(self, id):
-        """
-        pdf response and first image response from appdev upload service
-        
-        returns response tuple (<pdf_response>, <first_page_response>):
-        ({"success": <bool>, "data": "<pdf url?>"}, {"success": <bool>, "data": "<first page png url?>"})
-        """
-        creds = service_account.Credentials.from_service_account_file(
-            os.getenv("GOOGLE_SERVICE_ACCOUNT_PATH")
-        )
-        
-        try:
-            # create drive api client
-            service = build("drive", "v3", credentials=creds)
-
-            # pylint: disable=maybe-no-member
-            request = service.files().get_media(fileId=self.file_id)
-            file = io.BytesIO()
-            downloader = MediaIoBaseDownload(file, request)
-            done = False
-            while done is False:
-                status, done = downloader.next_chunk()
-                
-        except HttpError as error:
-            print(f"An error occurred: {error}")
-            file = None
-            
-        if file is not None:
-            pdf = pdfium.PdfDocument(file)
-            first_page = pdf[0]
-            pil_image = first_page.render().to_pil().resize((150,220))
-
-            imageBytes = io.BytesIO() #create bytes stream to hold image
-            pil_image.save(imageBytes, format='png')
-            
-            image_payload = json.dumps({
-                "bucket": "volume",
-                "image": "data:image/png;base64,"
-                + base64.b64encode(imageBytes.getvalue()).decode("utf-8")
-            })
-            
-            image_response = requests.post("https://upload.cornellappdev.com/upload/",image_payload).text
-
-            pdf_payload = json.dumps({
-                "bucket": UPLOAD_BUCKET,
-                "image": "data:application/pdf;base64,"
-                + base64.b64encode(file.getvalue()).decode("utf-8")
-            })
-            
-            pdf_response = requests.post("https://upload.cornellappdev.com/upload/",pdf_payload).text
-            
-            return (pdf_response, image_response)
-        return None
-
     def get_date(self, date):
         return date_parser.parse(date)
 
     def serialize(self):
-        pdf_response = self.download_magazine(id)[0]
-        image_response = self.download_magazine(id)[1]
-        
-        image_response_obj = json.loads(image_response)
-        if image_response_obj["success"]:
-            image_url = image_response_obj["data"]
-        else:
-            raise Exception
-        pdf_response_obj = json.loads(pdf_response)
-        if pdf_response_obj["success"]:
-            pdf_url = pdf_response_obj["data"]
-            return {
+        pdf_bytes = utils.download_bytes(self)
+        pdf_response = json.loads(utils.download_pdf(pdf_bytes))
+        image_response = json.loads(utils.download_image_from_pdf(pdf_bytes))
+        if pdf_response["success"] and image_response["success"]:
+            return { 
                 "date": self.get_date(self.timestamp),
                 "published": self.date_pub,
                 "semester": self.semester,
                 "title": self.title,
                 "publicationSlug": self.slug,
                 "publication": self.publication,
-                "pdfURL": pdf_url,
-                "imageURL": image_url,
+                "pdfURL": pdf_response["data"],
+                "imageURL": image_response["data"],
                 "isFiltered": self.is_profane(),
             }
         else:


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

I changed the output of download_magazine in src/magazine.py to be a tuple of the appdev-upload services response objects for both the magazine pdf and the cover image as a png. Previously, it only returned the pdf response.

To accommodate this change, I changed the Magazine's serialize method to include the imageURL field in the outputted python dictionary.

Two new libraries were required to make this change, PyPdfium2 (a pdf library) and Pillow (an image library).



## Changes Made

The changes made were to two methods of the Magazine class in magazine.py: <download_magazine> and <serialize>.

In <download_magazine>, the pdf is loaded as before into a BytesIO buffer, and then it is loaded as a PdfDocument object of PyPdfium2. The first page is retrieved, converted to a png using PIL, and scaled to 150x220 pixels (all within a BytesIO buffer) and then uploaded to the Digital Ocean appdev-upload service. The tuple containing the two response objects from the upload service is returned (and subsequently used by the <serialize> method.

In <serialize>, the tuple is parsed into the pdf url and image url, and the python dictionary that is returned was modified to include the png url. The method checks that both requests were successful.  


## Test Coverage

I tested this feature manually by running the micro service on many magazines and checking that the png's were properly uploaded to Digital Ocean, and that the new imageURL field was added.


## Next Steps (delete if not applicable)

Need to complete the migrations on dev and prod server (add the imageURL field by reprising the magazines). The issue of large file sizes is still a problem. 


## Related PRs or Issues (delete if not applicable)
73 in volume-backend (add the imageURL field to the mongo and graphql schemas.

## Screenshots (delete if not applicable)

<img width="1249" alt="Screen Shot 2023-04-03 at 9 14 14 PM" src="https://user-images.githubusercontent.com/104698418/229666448-596a3419-b8cd-42f3-89a5-8acf5045c124.png">

  <summary>Microservice running and resulting png files</summary>

<img width="1440" alt="Screen Shot 2023-04-03 at 9 35 58 PM" src="https://user-images.githubusercontent.com/104698418/229666701-f959d95a-2cbf-4a78-97bf-fb1f5b6155cb.png">


  <summary>Magazine with imageURL field added to db (required new volume-backend pr 73 to run)</summary>


