### PR TITLE
Parse Cornell Daily Sun pubDate and add Daily Sun rss feed back.

### DIFF
--- a/publications.json
+++ b/publications.json
@@ -397,7 +397,7 @@
       "bioShort": "Independent since 1880.",
       "contentTypes": ["articles"],
       "rssName": "The Cornell Daily Sun",
-      "rssURL": null,
+      "rssURL": "https://cornellsun.com/feed/",
       "name": "The Cornell Daily Sun",
       "slug": "sun",
       "socialURLs": [

--- a/src/article.py
+++ b/src/article.py
@@ -2,8 +2,7 @@ from better_profanity import profanity as pf
 from bs4 import BeautifulSoup
 from constants import PLACEHOLDER_IMAGE_ADDRESS, FILTERED_WORDS
 from dateutil import parser as date_parser
-
-
+import datetime
 class Article:
     def __init__(self, entry, publication):
         pf.load_censor_words(FILTERED_WORDS)
@@ -20,7 +19,24 @@ class Article:
             return img["src"] if img else default_image_url
         return default_image_url
 
+    def get_sun_date(self):
+        """
+        Given a <Cornell Daily Sun> Article object,
+        return the datetime object 
+        for the date it was published, based on the url scheme 
+        https://cornellsun.com/year/mo/day/article_name/
+        For example, https://cornellsun.com/2023/04/20/kempff-the-driving-battle-on-buffalo-street/
+        
+        Requires: self.publication["slug"] == "sun"
+        """
+        # get list of [year, month, day], where day and month are padded to 2 digits and year is 4 digits
+        year_month_day = self.entry.link.split('/')[3:6] 
+        return datetime.datetime(year=int(year_month_day[0]), month = int(year_month_day[1]), day=int(year_month_day[2]))
+        
     def get_date(self):
+        # Cornell Daily Sun's RSS feed has empty pubDate fields for all articles
+        if self.publication["slug"]=="sun":
+            return self.get_sun_date()
         return date_parser.parse(self.entry.published)
 
     def serialize(self):


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Since The Cornell Daily Sun's RSS feed has all empty <pubDate> fields, in order to add their articles to the database with a published date, we must parse their URLs which contain the date in them. 


## Changes Made

Create new method on article objects, get_sun_date, which is used to get the published date of a Cornell Daily Sun article.

Import datetime module.

Change get_date logic to account for Cornell Daily Sun issue.

Add back the RSS feed url to the publications.json since the feed parsing is now working.

## Test Coverage

Deleted all articles locally and reran microservice to make sure database is properly populated with Cornell Daily Sun articles.