### PR TITLE
update flyer organizations and organizationSlugs fields

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -164,7 +164,6 @@ def gather_flyers():
                 o = list(filter(lambda o: o["slug"] == slug, organizations_serialized))
                 
                 o = o[0] if o else None  # Get only one organization
-                print(o)
                 flyers.append(Flyer(data[i], o).serialize())
                 flyer_sheet.update_cell(i + 1, 12, 1)  # Updates parsed to equal 1
             else:

--- a/src/flyer.py
+++ b/src/flyer.py
@@ -1,6 +1,7 @@
 from better_profanity import profanity as pf
 from constants import FILTERED_WORDS
 
+import dateutil.parser as parser
 import json
 import utils
 
@@ -29,8 +30,8 @@ class Flyer:
         response = json.loads(utils.download_pdf(response_bytes))
         if response["success"]:
           return {
-              "startDate": self.date + "/" + self.start_time,
-              "endDate": self.date + "/" + self.end_time,
+              "startDate": parser.parse(self.date + "/" + self.start_time).isoformat(),
+              "endDate": parser.parse(self.date + "/" + self.end_time).isoformat(),
               "flyerURL": self.flyer_link,
               "imageURL": response["data"],
               "location": self.location,

--- a/src/flyer.py
+++ b/src/flyer.py
@@ -34,8 +34,8 @@ class Flyer:
               "flyerURL": self.flyer_link,
               "imageURL": response["data"],
               "location": self.location,
-              "organization": self.organization,
-              "organizationSlug": self.org_slug,
+              "organizations": [self.organization],
+              "organizationSlugs": [self.org_slug],
               "title": self.title
           }
         else:

--- a/src/flyer.py
+++ b/src/flyer.py
@@ -29,7 +29,8 @@ class Flyer:
         response = json.loads(utils.download_pdf(response_bytes))
         if response["success"]:
           return {
-              "date": self.date,
+              "startDate": self.date + "/" + self.start_time,
+              "endDate": self.date + "/" + self.end_time,
               "flyerURL": self.flyer_link,
               "imageURL": response["data"],
               "location": self.location,


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
- updated flyer organizations field and organizationSlugs fields to be lists
- parse dates with dateutil


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- when creating flyer objects, made the flyer organization field a list of organizations and the organizationSlug field a list of organizationSlugs
- updated to match the new schema on volume-backend
- used dateutil library to parse dates before adding them to flyer database for convenience


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
- runs locally


