### PR TITLE
Fixed organization and organizationSlugs field for flyers

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -1,6 +1,13 @@
 {
 	"organizations": [
 		{
+			"slug": "acsu",
+			"bio": "",
+			"categorySlug": "academic",
+			"name": "Cornell ACSU",
+			"websiteURL": "https://acsu.cornell.edu/"
+		},
+		{
 			"slug": "adr",
 			"bio": "",
 			"categorySlug": "dance",
@@ -82,7 +89,7 @@
 			"bio": "",
 			"categorySlug": "academic",
 			"name": "Campus Installation Artists",
-			"websiteURL": null
+			"websiteURL": "https://www.instagram.com/cia_cornell/"
 		},
 		{
 			"slug": "csa",
@@ -125,6 +132,13 @@
 			"categorySlug": "cultural",
 			"name": "Cornell Filipino Association",
 			"websiteURL": "https://www.instagram.com/cornellfilipino/?hl=en"
+		},
+		{
+			"slug": "ecua",
+			"bio": "",
+			"categorySlug": "cultural",
+			"name": "Ecuadorian Students’ Association",
+			"websiteURL": "https://www.instagram.com/ecuacornell/"
 		},
 		{
 			"slug": "fintech",
@@ -250,7 +264,7 @@
 			"bio": "",
 			"categorySlug": "dance",
 			"name": "Free Space",
-			"websiteURL": null
+			"websiteURL": "https://www.instagram.com/freespace.dance/"
 		},
 		{
 			"slug": "gva",

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pymongo==3.11.3
 pypdfium2==4.4.0
 python-dateutil==2.8.2 
 pytz==2023.3
-PyYAML==5.4.1
+PyYAML==5.3.1
 regex==2021.4.4
 requests==2.26.0
 schedule==1.1.0

--- a/src/flyer.py
+++ b/src/flyer.py
@@ -41,8 +41,8 @@ class Flyer:
               "flyerURL": self.flyer_link,
               "imageURL": response["data"],
               "location": self.location,
-              "organizations": [self.organization],
-              "organizationSlugs": [self.org_slug],
+              "organization": self.organization,
+              "organizationSlug": self.org_slug,
               "title": self.title
           }
         else:


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

The microservice for uploading flyers had outdated fields for organization and organizationSlug. 

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Previously organization and organizationSlug were named with the plural versions of the word. Additionally, the fields were stored in arrays. I changed it so that these field names were singular and also got rid of the array so that it would just return a singular object for organization and singular string for organizationSlug. 




## Screenshots (delete if not applicable)

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Screen Shot from graphql</summary>

<img width="1417" alt="Screenshot 2023-10-01 at 8 26 25 PM" src="https://github.com/cuappdev/volume-microservice/assets/67083541/29c0e316-3dec-4dca-ac7e-d459399051bd">

  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  

</details>